### PR TITLE
fixed issue with overriding strings that contain html entities

### DIFF
--- a/php/admin.php
+++ b/php/admin.php
@@ -82,7 +82,7 @@ class WP_Override_Translations_Admin {
 							<?php foreach ($translations as $key => $value) : ?>
 								<tr valign="top" id="row_id_<?php print $key; ?>_translate">
 									<td>
-										<input type="text" style="width:100%;" name="<?php print WP_OVERRIDE_TRANSLATIONS_LINES; ?>[original][]" value="<?php if (isset($value['original'])) echo esc_html($value['original']); ?>" />
+										<input type="text" style="width:100%;" name="<?php print WP_OVERRIDE_TRANSLATIONS_LINES; ?>[original][]" value="<?php if (isset($value['original'])) echo esc_html(htmlspecialchars($value['original'])); ?>" />
 									</td>
 									<td>
 										<input type="text" style="width:100%;" name="<?php print WP_OVERRIDE_TRANSLATIONS_LINES; ?>[overwrite][]" value="<?php if (isset($value['overwrite'])) echo esc_html($value['overwrite']); ?>" />


### PR DESCRIPTION
Before the stored translations are displayed in the administration page, they are sanitized using `esc_html()` WordPress function. This function internally uses native PHP `htmlspecialchars()` function, which converts unsafe characters nto HTML entities.

However, WordPress calls `htmlspecialchars()` with `double_encode` flag disabled, which means that if the text that is being sanitized already contains some HTML entities, they are left intact and therefore decoded when displayed on the front end.

This causes an issue with overriding strings that contain html entites (e.g. `&copy; 2022 Theme Name`). Even though the original value is stored successfully, it is displayed in the decoded form (`© 2022 Theme Name`), which means that on the next save, the value is overwritten with the decoded version and the override stops working, because the actual value to be overriden and the stored value no longer match.

This fix explicitly double-encodes entities in the stored value before passing it to `esc_html()` function so that the administration page displays it in its original form and the value is not overwritten with the decoded version after the next save.